### PR TITLE
[ADD] Add support for the MYGGSPRAY motion sensor

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -40,5 +40,8 @@
   },
   "1.0.13": {
     "en": "Added luminance support for Vallhorn sensors"
+  },
+  "1.0.14": {
+    "en": "Added support for the MYGGSPRAY motion sensor"
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -1,6 +1,6 @@
 {
   "id": "com.theeuwes-it.ikea.dirigera",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "compatibility": ">=5.0.0",
   "sdk": 3,
   "platforms": [

--- a/app.js
+++ b/app.js
@@ -137,7 +137,9 @@ class IkeaDirigeraGatewayApp extends Homey.App {
         }
         break;
     }
-    if (type == 'unknown' && deviceType === 'lightSensor') {
+    // Matter based sensors (MYGGSPRAY) are reported as an occupancySensor plus a
+    // separate lightSensor, and are not always announced with the 'sensor' type.
+    if (deviceType === 'occupancySensor' || deviceType === 'lightSensor') {
       driverId = 'motion-sensor';
     }
     if (driverId != null) {

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "_comment": "This file is generated. Please edit .homeycompose/app.json instead.",
   "id": "com.theeuwes-it.ikea.dirigera",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "compatibility": ">=5.0.0",
   "sdk": 3,
   "platforms": [

--- a/drivers/motion-sensor/driver.js
+++ b/drivers/motion-sensor/driver.js
@@ -17,7 +17,9 @@ module.exports = class DirigeraMotionSensorDriver extends DirigeraDriver {
     const devices = await this.homey.app.getDevices();
     const motionSensors = [];
     for (const device of devices) {
-      if (device.type !== 'sensor' || device.deviceType !== 'motionSensor') {
+      // MYGGSPRAY is a Matter device and reports itself as an occupancySensor
+      // instead of a motionSensor.
+      if (device.deviceType !== 'motionSensor' && device.deviceType !== 'occupancySensor') {
         continue;
       }
 


### PR DESCRIPTION
## Summary

Adds support for the IKEA **MYGGSPRAY** wireless motion sensor (type E2494).

MYGGSPRAY is a Matter over Thread device rather than Zigbee, and the DIRIGERA hub
describes it differently from VALLHORN:

* the motion half is reported with `deviceType: "occupancySensor"` instead of `"motionSensor"`
* the light half is reported as a separate `lightSensor` device sharing the same `relationId`
* it does not expose an `isOn` attribute, only `isDetected`

Because `drivers/motion-sensor/driver.js` filtered on
`device.type !== 'sensor' || device.deviceType !== 'motionSensor'`, MYGGSPRAY never showed
up in the pairing list at all.

## Changes

* `drivers/motion-sensor/driver.js` — match on `deviceType` and accept both `motionSensor`
  and `occupancySensor`. The `type` check is dropped because Matter devices are not
  consistently announced with `type: "sensor"`, and `deviceType` is already specific enough
  to identify the device on its own.
* `app.js` — route `occupancySensor` to the motion sensor driver, and make the existing
  `lightSensor` route depend on `deviceType` only, for the same reason. The previous
  `type == 'unknown' && deviceType === 'lightSensor'` case is still covered by this.
* Version bump to 1.0.14 plus a changelog entry.

I extended the existing `motion-sensor` driver instead of adding a new one: MYGGSPRAY maps
onto exactly the same capabilities as VALLHORN (`alarm_motion`, `measure_luminance`,
`measure_battery`), and the split-device `relationId` handling added in
"Added luminance support for Vallhorn sensors" already does the right thing here. A separate
driver would duplicate that logic and split the device list for no user-visible benefit.

## Note on `measure_luminance`

Luminance is passed through unchanged, exactly as it is for VALLHORN today.

Worth flagging for review: the two other DIRIGERA integrations disagree on whether the hub
normalises this value for Matter sensors. The Home Assistant `dirigera_platform` integration
treats MYGGSPRAY's `illuminance` as a raw Matter/ZCL measurement and converts it with
`lux = 10^((raw - 1) / 10000)`, while the openHAB binding documents the same field as plain
lux for both VALLHORN and MYGGSPRAY. I could not verify which applies here, so I left the
existing behaviour alone rather than guess. If the hub does pass the raw value through, a
follow-up conversion will be needed for `occupancySensor`-linked light sensors — motion and
battery reporting are unaffected either way.

## Test plan

- [ ] Pair a MYGGSPRAY via the motion sensor driver and confirm it appears in the device list
- [ ] Confirm `alarm_motion` toggles on motion and clears afterwards (~25-30s hold time)
- [ ] Confirm `measure_battery` reports a plausible percentage
- [ ] Confirm `measure_luminance` reports a plausible lux value, and report back if it looks
      like a raw Matter value instead (e.g. ~27000 in a dim room)
- [ ] Confirm existing VALLHORN and TRADFRI motion sensors still pair and update correctly

A Homey diagnostic report with the raw hub payload was submitted from my Homey under id
`30c67986-74fc-46be-8258-7f3f33969501` — that should show the exact `type`, `deviceType`,
`relationId` and attribute values my MYGGSPRAY reports, including the raw `illuminance`.

`npm run lint` currently fails on all 15 source files, including untouched ones, because there
is no `.eslintrc` and ESLint 7 falls back to ES5 parsing. That is pre-existing and I have left
it out of this PR to keep the diff focused.
