### PR TITLE
[FIX] Fix MYGGSPRAY luminance readings

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -43,5 +43,8 @@
   },
   "1.0.14": {
     "en": "Added support for the MYGGSPRAY motion sensor"
+  },
+  "1.0.15": {
+    "en": "Fixed the luminance readings of the MYGGSPRAY motion sensor"
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -1,6 +1,6 @@
 {
   "id": "com.theeuwes-it.ikea.dirigera",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "compatibility": ">=5.0.0",
   "sdk": 3,
   "platforms": [

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "_comment": "This file is generated. Please edit .homeycompose/app.json instead.",
   "id": "com.theeuwes-it.ikea.dirigera",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "compatibility": ">=5.0.0",
   "sdk": 3,
   "platforms": [

--- a/drivers/motion-sensor/device.js
+++ b/drivers/motion-sensor/device.js
@@ -29,9 +29,17 @@ module.exports = class DirigeraMotionSensorDevice extends DirigeraDevice {
             .catch(this.error);
       }
 
+      // Only the occupancySensor half of a MYGGSPRAY identifies it as a Matter
+      // device, while illuminance arrives from its lightSensor half. Remember it
+      // here so sensors that were paired before this flag existed are corrected too.
+      if (sensor.deviceType === 'occupancySensor' && !this.getStoreValue('matterIlluminance')) {
+        this.setStoreValue('matterIlluminance', true)
+            .catch(this.error);
+      }
+
       var illuminance = sensor.attributes['illuminance'];
       if (illuminance !== undefined) {
-        this.setCapabilityValue('measure_luminance', illuminance)
+        this.setCapabilityValue('measure_luminance', this.toLux(illuminance))
             .catch(this.error);
       }
 
@@ -41,5 +49,21 @@ module.exports = class DirigeraMotionSensorDevice extends DirigeraDevice {
             .catch(this.error);
       }
     }
+  }
+
+  /*
+   * Matter reports illuminance on the logarithmic scale it shares with Zigbee:
+   * MeasuredValue = 10000 * log10(lux) + 1, where 0 means 'too low to measure'.
+   * The gateway resolves this to lux for Zigbee sensors such as Vallhorn, but
+   * passes the raw value straight through for Matter sensors such as MYGGSPRAY.
+   */
+  toLux(illuminance) {
+    if (!this.getStoreValue('matterIlluminance')) {
+      return illuminance;
+    }
+    if (illuminance <= 0) {
+      return 0;
+    }
+    return Math.round(Math.pow(10, (illuminance - 1) / 10000) * 10) / 10;
   }
 }

--- a/drivers/motion-sensor/driver.js
+++ b/drivers/motion-sensor/driver.js
@@ -34,6 +34,9 @@ module.exports = class DirigeraMotionSensorDriver extends DirigeraDriver {
           id: id,
         },
         capabilities,
+        store: {
+          matterIlluminance: device.deviceType === 'occupancySensor',
+        },
         name: (device['attributes'].customName !== '' ? device['attributes'].customName : device['attributes'].model),
       });
     }


### PR DESCRIPTION
## Summary

Follow-up to #26, which flagged this as unverified.

The MYGGSPRAY illuminance question from that PR is now answered with a real reading: a
MYGGSPRAY in a dim room reported **20294** through `measure_luminance`. That is the raw
Matter/ZCL measured value, not lux — `10^((20294 - 1) / 10000)` works out to about
**107 lux**, which matches the room. Displayed as-is, 20294 lx reads as direct sunlight, so
any lux threshold in a flow would never behave correctly.

So the gateway resolves illuminance to lux for Zigbee sensors such as Vallhorn, but passes
the raw value straight through for Matter sensors such as MYGGSPRAY.

## Changes

* `drivers/motion-sensor/device.js` — add `toLux()`, applying
  `lux = 10^((MeasuredValue - 1) / 10000)` and mapping the reserved `0`
  ("too low to be measured") to `0` rather than `1`.
* `drivers/motion-sensor/driver.js` — record a `matterIlluminance` store flag at pair time
  for devices reporting `deviceType: "occupancySensor"`.
* Version bump to 1.0.15 plus a changelog entry.

The conversion is deliberately gated behind that per-device flag rather than applied
unconditionally, so **Vallhorn and TRADFRI behaviour is untouched**. Applying it everywhere
would turn a genuine 500 lux Vallhorn reading into 1.1 lx.

Both halves of a MYGGSPRAY share a `relationId` and therefore map onto one Homey device, but
only the `occupancySensor` half identifies it as Matter while illuminance arrives from the
`lightSensor` half. The flag is set at pair time and also re-checked on every update, so
sensors paired under 1.0.14 correct themselves on the next motion event without needing to be
removed and re-added.

Sample conversions:

| raw | lux |
| --- | --- |
| 0 | 0 |
| 6990 | 5 |
| 20294 | 107 |
| 30000 | 999.8 |
| 50001 | 100000 |

## Test plan

- [ ] Confirm a MYGGSPRAY paired under 1.0.14 starts reporting plausible lux after the next
      motion event, without re-pairing
- [ ] Confirm a freshly paired MYGGSPRAY reports plausible lux immediately
- [ ] Confirm a Vallhorn still reports the same lux values as before

One thing worth a second opinion, since I only have a MYGGSPRAY to test with: it would be
good to confirm that Vallhorn really is normalised to lux by the gateway. Zigbee uses the
identical logarithmic encoding, so if the hub passes Vallhorn's value through as well, then
the flag should be dropped and the conversion applied unconditionally. A Vallhorn reading in
a normally lit room (roughly 100-300 lx expected) would settle it.
