### PR TITLE
Fix GRILLPLATS (relationId-split outlets) crash + add energy monitoring

### DIFF
--- a/app.js
+++ b/app.js
@@ -106,7 +106,7 @@ class IkeaDirigeraGatewayApp extends Homey.App {
   async getDevice(id) {
     const devices = await this.getDevices();
     for (const device of devices) {
-      if (device.id === id) {
+      if (device.id === id || device.relationId === id) {
         return device;
       }
     }
@@ -116,6 +116,11 @@ class IkeaDirigeraGatewayApp extends Homey.App {
   /*
    * @returns DirigeraDriver
    */
+  async getRelatedDevices(relationId) {
+    const devices = await this.getDevices();
+    return devices.filter(device => device.id === relationId || device.relationId === relationId);
+  }
+
   getDriverForType(type, deviceType) {
     let driverId = null;
     switch (type) {
@@ -139,6 +144,9 @@ class IkeaDirigeraGatewayApp extends Homey.App {
     }
     // Matter based sensors (MYGGSPRAY) are reported as an occupancySensor plus a
     // separate lightSensor, and are not always announced with the 'sensor' type.
+    if (deviceType === 'electricalSensor') {
+      driverId = 'outlet';
+    }
     if (deviceType === 'occupancySensor' || deviceType === 'lightSensor') {
       driverId = 'motion-sensor';
     }

--- a/drivers/outlet/device.js
+++ b/drivers/outlet/device.js
@@ -8,30 +8,60 @@ module.exports = class DirigeraOutletDevice extends DirigeraDevice {
     this._instanceId = this.getData().id;
     const device = await this.homey.app.getDevice(this._instanceId);
     await this.updateSettings(device);
-    this.updateCapabilities(device);
+    this._realId = device ? device.id : this._instanceId;
+
+    const newCaps = ['measure_power', 'measure_voltage', 'measure_current', 'meter_power'];
+    for (const cap of newCaps) {
+      if (!this.hasCapability(cap)) {
+        await this.addCapability(cap).catch(this.error);
+      }
+    }
+
+    const related = await this.homey.app.getRelatedDevices(this._instanceId);
+    this.updateCapabilities(device, related);
+
     this.registerCapabilityListener('onoff', async (value) => {
       const dirigera = this.homey.app.getDirigera();
       if (this.isDebugLoggingEnabled()) {
         this.log(`${this.getName()} - onoff: Setting outlet state to ${value}`);
       }
-      dirigera.setAttribute(this._instanceId, { 'isOn': value });
+      dirigera.setAttribute(this._realId, { 'isOn': value });
     })
     this.log(`Dirigera Outlet ${this.getName()} has been initialized`);
   }
 
-  updateCapabilities(outlet) {
-    if (typeof outlet !== 'undefined') {
+  updateCapabilities(status, related) {
+    if (status == null) return;
 
-      if (outlet.isReachable) {
-        this.setAvailable()
-            .catch(this.error);
+    const isSensorStatus = status.deviceType === 'electricalSensor';
+
+    if (!isSensorStatus) {
+      if (status.isReachable) {
+        this.setAvailable().catch(this.error);
       } else {
-        this.setUnavailable('(temporary) unavailable')
-            .catch(this.error);
+        this.setUnavailable('(temporary) unavailable').catch(this.error);
       }
-      if (this.hasCapability('onoff')) {
-        this.setCapabilityValue('onoff', outlet.attributes['isOn'])
-            .catch(this.error);
+      if (this.hasCapability('onoff') && status.attributes && 'isOn' in status.attributes) {
+        this.setCapabilityValue('onoff', status.attributes['isOn']).catch(this.error);
+      }
+    }
+
+    const sensorAttrs = isSensorStatus
+        ? status.attributes
+        : (related || []).find(d => d.deviceType === 'electricalSensor')?.attributes;
+
+    if (sensorAttrs != null) {
+      if (this.hasCapability('measure_power') && typeof sensorAttrs.currentActivePower === 'number') {
+        this.setCapabilityValue('measure_power', sensorAttrs.currentActivePower).catch(this.error);
+      }
+      if (this.hasCapability('measure_voltage') && typeof sensorAttrs.currentVoltage === 'number') {
+        this.setCapabilityValue('measure_voltage', sensorAttrs.currentVoltage).catch(this.error);
+      }
+      if (this.hasCapability('measure_current') && typeof sensorAttrs.currentAmps === 'number') {
+        this.setCapabilityValue('measure_current', sensorAttrs.currentAmps).catch(this.error);
+      }
+      if (this.hasCapability('meter_power') && typeof sensorAttrs.totalEnergyConsumed === 'number') {
+        this.setCapabilityValue('meter_power', sensorAttrs.totalEnergyConsumed).catch(this.error);
       }
     }
   }

--- a/drivers/outlet/device.js
+++ b/drivers/outlet/device.js
@@ -27,7 +27,24 @@ module.exports = class DirigeraOutletDevice extends DirigeraDevice {
       }
       dirigera.setAttribute(this._realId, { 'isOn': value });
     })
+
+    this._pollInterval = this.homey.setInterval(async () => {
+      try {
+        const freshDevice = await this.homey.app.getDevice(this._instanceId);
+        const freshRelated = await this.homey.app.getRelatedDevices(this._instanceId);
+        this.updateCapabilities(freshDevice, freshRelated);
+      } catch (err) {
+        this.error('Poll refresh failed:', err);
+      }
+    }, 60000);
+
     this.log(`Dirigera Outlet ${this.getName()} has been initialized`);
+  }
+
+  async onUninit() {
+    if (this._pollInterval) {
+      this.homey.clearInterval(this._pollInterval);
+    }
   }
 
   updateCapabilities(status, related) {

--- a/drivers/outlet/driver.compose.json
+++ b/drivers/outlet/driver.compose.json
@@ -4,7 +4,11 @@
   },
   "class": "socket",
   "capabilities": [
-    "onoff"
+    "onoff",
+    "measure_power",
+    "measure_voltage",
+    "measure_current",
+    "meter_power"
   ],
   "platforms": [
     "local"


### PR DESCRIPTION
## Problem

GRILLPLATS (and likely TOFSMYGGA, TIMMERFLOTTE, MYGGSPRAY) report as two
linked API objects sharing the same `relationId`: one `type: "outlet"`
object with the `isOn` switch, and one `type: "unknown"` /
`deviceType: "electricalSensor"` object with power/energy attributes
(`currentActivePower`, `currentVoltage`, `currentAmps`, `totalEnergyConsumed`).

This causes two bugs and one missing feature:

1. **Crash on init** (fixes #24): `onPairListDevices()` stores the device's
   `relationId` as the Homey device ID (via `getIdFromDevice()`), but
   `getDevice(id)` only matches on the raw `device.id`, never `relationId`.
   Lookups after pairing return `null`, and `updateCapabilities()` only
   guards against `undefined`, not `null`, causing
   `Cannot read properties of null (reading 'isReachable')`.
2. **On/off commands silently do nothing**: the `onoff` capability listener
   calls `dirigera.setAttribute(this._instanceId, ...)` with the relationId.
   `dirigera-simple`'s internal `getDevice()` only matches raw `device.id`,
   so the lookup fails, logs a debug message, and returns without sending
   any PATCH request — no error, no effect.
3. **No energy monitoring**: the outlet driver only ever declares/reads the
   `onoff` capability; the linked `electricalSensor` object is completely
   ignored.

## Fix

- `app.js`: `getDevice(id)` now also matches on `relationId`.
- `drivers/outlet/device.js`: store the real `device.id` separately
  (`_realId`) for control calls, instead of reusing the relationId-based
  `_instanceId`.
- `app.js`: added `getRelatedDevices(relationId)` and mapped
  `deviceType: "electricalSensor"` to the outlet driver in
  `getDriverForType()` so live sensor updates route correctly.
- `drivers/outlet/driver.compose.json`: added `measure_power`,
  `measure_voltage`, `measure_current`, `meter_power` capabilities.
- `drivers/outlet/device.js`: `updateCapabilities()` rewritten to handle
  both switch-status and sensor-status update objects, and to backfill
  new capabilities on already-paired devices via `addCapability()`.

Tested against a real GRILLPLATS (firmware 1.4.6) via Homey Self-Hosted
Server. Fixes #24.