### PR TITLE
Auto-reconnect to DIRIGERA gateway when IP/token settings change

### DIFF
--- a/app.js
+++ b/app.js
@@ -21,6 +21,27 @@ class IkeaDirigeraGatewayApp extends Homey.App {
         this.log(`Error: ${err.message}`);
       }
     })();
+
+    // Re-connect automatically whenever the IP address or access token is
+    // (re-)configured on the settings page, instead of requiring a manual
+    // app restart. Debounced because the settings page saves several keys
+    // in quick succession during the authentication flow.
+    this.homey.settings.on('set', (key) => {
+      if (key !== 'ipAddress' && key !== 'accessToken') {
+        return;
+      }
+      if (this._reconnectTimeout) {
+        this.homey.clearTimeout(this._reconnectTimeout);
+      }
+      this._reconnectTimeout = this.homey.setTimeout(async () => {
+        this.log(`Setting '${key}' changed, reconnecting to DIRIGERA gateway...`);
+        try {
+          await this.connect();
+        } catch (err) {
+          this.log(`Error reconnecting: ${err.message}`);
+        }
+      }, 2000);
+    });
   }
 
   async connect() {


### PR DESCRIPTION
## Problem

After (re-)authenticating with the DIRIGERA gateway from the app's settings
page (e.g. after a token expired, or after changing the hub's IP address),
the running app kept using its old, stale `Dirigera` connection. The new
credentials were saved correctly, but nothing ever triggered a reconnect —
the app had to be manually restarted for the change to take effect.

This isn't specific to any one device; it affects any pairing/control
attempt made after a re-authentication until the app is restarted.

## Fix

`connect()` already tears down the previous connection safely
(`stopListeningForUpdates()`) before creating a new one, so it's safe to
call repeatedly. This adds a `homey.settings.on('set', ...)` listener in
`onInit()` that calls `connect()` again whenever `ipAddress` or
`accessToken` changes, debounced by 2 seconds since the settings page saves
several keys in quick succession during the authentication flow.

Verified against a real DIRIGERA hub: re-running the authentication flow
now logs `Setting 'accessToken' changed, reconnecting to DIRIGERA
gateway...` followed by `Connected to DIRIGERA gateway`, with no manual
restart needed.

Unrelated to #29 — split into its own PR on purpose.